### PR TITLE
Use the user api token for the kernel requests

### DIFF
--- a/jupyterhub_client/api.py
+++ b/jupyterhub_client/api.py
@@ -47,7 +47,13 @@ class JupyterHubAPI:
         async with self.session.post(self.api_url / 'users' / username) as response:
             if response.status == 201:
                 logger.info(f'created username={username}')
-                return await response.json()
+                resp = await response.json()
+                # Create a new token for the user
+                async with self.session.post(self.api_url / 'users' / username / 'tokens') as r:
+                    token_resp = await r.json()
+                    # Use the user token to authenticate the following kernel requests
+                    self.api_token = token_resp['token']
+                return resp
             elif response.status == 409:
                 raise ValueError(f'username={username} already exists')
             print(response.status, await response.content.read())


### PR DESCRIPTION
### What does this PR do
This PR requests a token from JupyterHub for the temporary user that `jupyterhub_client` creates and uses that token to authenticate the kernel requests that follow.

### Reasoning behind
When trying to use `jupyterhub_client` to create a JupyterHub service that would check if a hub is "healthy" (by creating a temporary user and executing a test notebook), I got a 403 from `SingleUserNotebookApp` (triggered by the `ensure_kernel` func):
```
[W 2020-12-16 13:51:41.928 SingleUserNotebookApp auth:870] Not allowing Hub service hub-health-check
[W 2020-12-16 13:51:41.930 SingleUserNotebookApp web:1786] 403 GET /user/service-hub-health-check-470d10bc-a124-4812-a3a9-0087f62acbca/api/kernelspecs (::ffff:127.0.0.1): service hub-health-check is not allowed.
[W 2020-12-16 13:51:41.930 SingleUserNotebookApp handlers:608] service hub-health-check is not allowed.
[W 2020-12-16 13:51:41.930 SingleUserNotebookApp log:181] 403 GET /user/service-hub-health-check-470d10bc-a124-4812-a3a9-0087f62acbca/api/kernelspecs (@::ffff:127.0.0.1) 56.98ms
``` 

The JupyterHub config that I used:
```
c.JupyterHub.services = [
   {
       "name": "hub-health-check",
       "admin": True,
       "api_token":  "super-secret",
       "command": ["jhubctl", "run", "--temporary-user", "--notebook", "simple.ipynb", "--hub", "http://127.0.0.1:8000"]
   }
]
```

From the looks of it, executing operations on a user's notebook by authenticated as the service that created that user is not allowed.

This PR solves this issue and should not interfere with the cases when there's no JupyterHub service and a user api token is used. Is there a better approach to solve this? What do you think?