### PR TITLE
Fix env var name typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Access the hub control page. The url will be `<hub_url>/hub/home`.
 
 Click on `Token` in top left corner and request new api token. This
 token will have the permissions of the user. Make sure to set the
-environment variable `JUPYTERLAB_API_TOKEN` to the value of the given
+environment variable `JUPYTERHUB_API_TOKEN` to the value of the given
 token.
 
 ![qhub token](./images/token.png)


### PR DESCRIPTION
I inspected the code base and found no other reference to JUPYTERLAB_API_TOKEN but several to JUPYTERHUB_API_TOKEN, so I presume this is a typo in a readme referencing jupyterLAB rather jupyterHUB.