### PR TITLE
Returning status from delete_server and new method ensure_server_deleted

### DIFF
--- a/jhub_client/api.py
+++ b/jhub_client/api.py
@@ -123,6 +123,27 @@ class JupyterHubAPI:
 
             logger.info(f"pending spawn polling for seconds={total_time:.0f} [s]")
 
+    async def ensure_server_deleted(self, username, timeout):
+        user = await self.get_user(username)
+        if user is None:
+            return # user doesn't exist so server can't exist
+
+        start_time = time.time()
+        while True:
+            server_status = self.delete_server(username)
+            if server_status == 204:
+                return
+
+            await asyncio.sleep(5)
+            total_time = time.time() - start_time
+            if total_time > timeout:
+                logger.error(f"jupyterhub server deletion timeout={timeout:.0f} [s]")
+                raise TimeoutError(
+                    f"jupyterhub server deletion timeout={timeout:.0f} [s]"
+                )
+
+            logger.info(f"pending spawn polling for seconds={total_time:.0f} [s]")
+
     async def create_token(self, username, token_name=None):
         token_name = token_name or "jhub-client"
         async with self.session.post(
@@ -148,8 +169,9 @@ class JupyterHubAPI:
                 return True
 
     async def delete_server(self, username):
-        await self.session.delete(self.api_url / "users" / username / "server")
+        response = await self.session.delete(self.api_url / "users" / username / "server")
         logger.info(f"deleted server for username={username}")
+        return response.status
 
     async def info(self):
         async with self.session.get(self.api_url / "info") as response:

--- a/jhub_client/api.py
+++ b/jhub_client/api.py
@@ -142,7 +142,7 @@ class JupyterHubAPI:
                     f"jupyterhub server deletion timeout={timeout:.0f} [s]"
                 )
 
-            logger.info(f"pending spawn polling for seconds={total_time:.0f} [s]")
+            logger.info(f"pending deletion polling for seconds={total_time:.0f} [s]")
 
     async def create_token(self, username, token_name=None):
         token_name = token_name or "jhub-client"

--- a/jhub_client/api.py
+++ b/jhub_client/api.py
@@ -126,7 +126,7 @@ class JupyterHubAPI:
     async def ensure_server_deleted(self, username, timeout):
         user = await self.get_user(username)
         if user is None:
-            return # user doesn't exist so server can't exist
+            return  # user doesn't exist so server can't exist
 
         start_time = time.time()
         while True:
@@ -169,7 +169,9 @@ class JupyterHubAPI:
                 return True
 
     async def delete_server(self, username):
-        response = await self.session.delete(self.api_url / "users" / username / "server")
+        response = await self.session.delete(
+            self.api_url / "users" / username / "server"
+        )
         logger.info(f"deleted server for username={username}")
         return response.status
 

--- a/jhub_client/api.py
+++ b/jhub_client/api.py
@@ -130,7 +130,7 @@ class JupyterHubAPI:
 
         start_time = time.time()
         while True:
-            server_status = self.delete_server(username)
+            server_status = await self.delete_server(username)
             if server_status == 204:
                 return
 

--- a/jhub_client/execute.py
+++ b/jhub_client/execute.py
@@ -58,6 +58,7 @@ async def execute_code(
     create_user=False,
     delete_user=False,
     server_creation_timeout=60,
+    server_deletion_timeout=60,
     kernel_execution_timeout=60,
     daemonized=False,
     validate=False,
@@ -137,10 +138,10 @@ async def execute_code(
                 if not daemonized:
                     await jupyter.delete_kernel(kernel_id)
             if not daemonized and stop_server:
-                await hub.delete_server(username)
+                await hub.ensure_server_deleted(username)
         finally:
             if delete_user and not daemonized:
-                await hub.delete_user(username)
+                await hub.delete_user(username, timeout=server_deletion_timeout)
 
         return result_cells
 

--- a/jhub_client/execute.py
+++ b/jhub_client/execute.py
@@ -138,10 +138,10 @@ async def execute_code(
                 if not daemonized:
                     await jupyter.delete_kernel(kernel_id)
             if not daemonized and stop_server:
-                await hub.ensure_server_deleted(username)
+                await hub.ensure_server_deleted(username, timeout=server_deletion_timeout)
         finally:
             if delete_user and not daemonized:
-                await hub.delete_user(username, timeout=server_deletion_timeout)
+                await hub.delete_user(username)
 
         return result_cells
 

--- a/jhub_client/execute.py
+++ b/jhub_client/execute.py
@@ -138,7 +138,9 @@ async def execute_code(
                 if not daemonized:
                     await jupyter.delete_kernel(kernel_id)
             if not daemonized and stop_server:
-                await hub.ensure_server_deleted(username, timeout=server_deletion_timeout)
+                await hub.ensure_server_deleted(
+                    username, timeout=server_deletion_timeout
+                )
         finally:
             if delete_user and not daemonized:
                 await hub.delete_user(username)


### PR DESCRIPTION
Closes #14

This does two things:
  - `delete_server` now return the status code of the request either 202 or 204
  - new method `ensure_server_deleted` which uses a timeout to ensure that a given server is deleted