### PR TITLE
Fix crash when token env var isn't set

### DIFF
--- a/jhub_client/api.py
+++ b/jhub_client/api.py
@@ -21,13 +21,13 @@ class JupyterHubAPI:
         self.verify_ssl = verify_ssl
 
         if auth_type == "token":
-            self.api_token = kwargs.get("api_token", os.environ["JUPYTERHUB_API_TOKEN"])
-        elif auth_type == "basic":
-            self.username = kwargs.get("username", os.environ["JUPYTERHUB_USERNAME"])
-            self.password = kwargs.get("password", os.environ["JUPYTERHUB_PASSWORD"])
-        elif auth_type == "keycloak":
-            self.username = kwargs.get("username", os.environ["JUPYTERHUB_USERNAME"])
-            self.password = kwargs.get("password", os.environ["JUPYTERHUB_PASSWORD"])
+            # Only look for the env var if api_token isn't explicitly passed.
+            # Otherwise, we always try to read the env var even if it isn't necessary,
+            # and this can crash if the env var isn't set.
+            self.api_token = kwargs.get("api_token") or os.environ["JUPYTERHUB_API_TOKEN"]
+        elif auth_type == "basic" or auth_type == "keycloak":
+            self.username = kwargs.get("username") or os.environ['JUPYTERHUB_USERNAME']
+            self.password = kwargs.get("password") or os.environ['JUPYTERHUB_PASSWORD']
 
     async def __aenter__(self):
         if self.auth_type == "token":


### PR DESCRIPTION
Currently, if you try to instanticate a JupyterHubAPI by
passing in an api_token but don't set JUPYTERHUB_API_TOKEN,
it crashes as it tries to read the env var unconditionally.

This commit makes the read on the env var conditional